### PR TITLE
Updated build scripts for Electron target

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ The client itself is a web app written in Nuxt.js (a Vue framework).
 You can get a local development server with hot reloading running with
 `npm run dev`.
 
-If you want to build the static files, do `npm run generate`.
+If you want to build the static files to `/dist`, do `npm run generate`.
 
 ### Standalones
 
@@ -22,7 +22,7 @@ are coming up soon ahead.
 
 To build for Electron:
 ```shell
-npx cap sync @capacitor-community/electron
-cd electron
-npm run build:electron-windows # or whatever your platform is
+cd electron && npm ci && cd .. # Install electron build dependencies
+npm run build:electron # or electron-windows for specific OS
+# Your build is now in electron/dist/
 ```

--- a/electron/package.json
+++ b/electron/package.json
@@ -8,6 +8,7 @@
     "electron:start": "npm run build && electron ./",
     "electron:pack": "npm run build && electron-builder build --dir",
     "electron:build-windows": "npm run build && electron-builder build --windows",
+    "electron:build-linux": "npm run build && electron-builder build --linux",
     "electron:build-mac": "npm run build && electron-builder build --mac"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,11 @@
     "dev": "nuxt",
     "start": "nuxt start",
     "generate": "nuxt generate",
-    "build:electron": "cross-env CAPACITOR_CONFIG=./capacitor.config.json CAPACITOR_ROOT_DIR=./ CAPACITOR_WEB_DIR=./dist npx cap sync @capacitor-community/electron"
+    "open:electron": "cap open @capacitor-community/electron",
+    "build:electron": "cd electron && npm run electron:pack",
+    "build:electron-windows": "cd electron && npm run electron:build-windows",
+    "build:electron-mac": "cd electron && npm run electron:build-mac",
+    "build:electron-linux": "cd electron && npm run electron:build-linux"
   },
   "dependencies": {
     "@nuxtjs/axios": "^5.13.1",
@@ -18,7 +22,6 @@
     "@capacitor-community/electron": "^1.3.3",
     "@capacitor/cli": "^2.4.6",
     "@capacitor/core": "^2.4.6",
-    "@nuxtjs/vuetify": "^1.11.3",
-    "cross-env": "^7.0.3"
+    "@nuxtjs/vuetify": "^1.11.3"
   }
 }


### PR DESCRIPTION
Updated README for Electron builds.
Added the following build scripts to top level:
 - `open:electron`
 - `build:electron`
 - `build:electron-windows`
 - `build:electron-mac`
 - `build:electron-linux`