### PR TITLE
feat: Add persistent session/credential/message storage

### DIFF
--- a/assets/storage.js
+++ b/assets/storage.js
@@ -1,0 +1,11 @@
+export const session = window.sessionStorage;
+
+export const permanent = window.localStorage;
+
+export const secure = window.localStorage;
+
+export const loadFromStorage = (storage, ...args) => args.map(key => JSON.parse(storage.getItem(key)));
+
+export const loadFromSession = (...args) => loadFromStorage(session, ...args);
+export const loadFromPermanent = (...args) => loadFromStorage(permanent, ...args);
+export const loadFromSecure = (...args) => loadFromStorage(secure, ...args);

--- a/middleware/loginRedirect.js
+++ b/middleware/loginRedirect.js
@@ -1,0 +1,17 @@
+import { Store } from '@/store';
+
+export default async function({ store, redirect, route }) {
+    // Let /login's anonymous middleware handle this
+    if(route.path === "/login") {
+        return;
+    }
+
+    // If not logged in, maybe we have a session/credentials stored; use those to log in.
+    if(!store.state[Store.$states.loggedIn]) {
+        await store.dispatch(Store.$actions.tryRestoreSession);
+
+        // Are we still not logged in?
+        if(!store.state[Store.$states.loggedIn])
+            return redirect('/login');
+    }
+}

--- a/middleware/loginRedirect.js
+++ b/middleware/loginRedirect.js
@@ -7,11 +7,11 @@ export default async function({ store, redirect, route }) {
     }
 
     // If not logged in, maybe we have a session/credentials stored; use those to log in.
-    if(!store.state[Store.$states.loggedIn]) {
+    if(!store.getters[Store.$getters.loggedIn]) {
         await store.dispatch(Store.$actions.tryRestoreSession);
 
         // Are we still not logged in?
-        if(!store.state[Store.$states.loggedIn])
+        if(!store.getters[Store.$getters.loggedIn])
             return redirect('/login');
     }
 }

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -26,6 +26,10 @@ export default {
     ]
   },
 
+  router: {
+    middleware: ['loginRedirect'],
+  },
+
   // Global CSS: https://go.nuxtjs.dev/config-css
   css: [
       '@/assets/globals.scss'

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -3,20 +3,8 @@
 </template>
 
 <script>
-  import { Store } from '@/store';
-  import { mapState } from 'vuex';
-
   export default {
     name: "index",
-    computed: {
-      ...mapState({
-        loggedIn: Store.$states.loggedIn,
-      })
-    },
-
-    mounted() {
-      // if(!this.loggedIn) this.$router.push('/login');
-    }
   }
 </script>
 

--- a/pages/login.vue
+++ b/pages/login.vue
@@ -11,7 +11,7 @@
   import LoginDialog from "../components/Login/LoginDialog";
 
   import { Store } from '@/store';
-  import { mapState, mapActions } from "vuex";
+  import { mapGetters, mapActions } from "vuex";
 
   export default {
     name: "login",
@@ -19,7 +19,7 @@
 
     async middleware({store, redirect}) {
       // You're logged in; you have no business being here. Scram
-      if(store.state[Store.$states.loggedIn]) {
+      if(store.getters[Store.$getters.loggedIn]) {
         return redirect('/');
       }
 
@@ -28,14 +28,14 @@
       await store.dispatch(Store.$actions.tryRestoreSession);
 
       // If we logged in that way, redirect to /
-      if(store.state[Store.$states.loggedIn])
+      if(store.getters[Store.$getters.loggedIn])
         return redirect('/');
     },
 
     methods: {
       async submit({jid, password, transports}) {
         await this.login({jid, password, transports});
-        if(this.loggedIn) return this.redirect('/');
+        if(this.loggedIn) return this.$router.push('/');
       },
 
       ...mapActions({
@@ -44,19 +44,19 @@
     },
 
     computed: {
-      ...mapState({
-        'loggedIn': Store.$states.loggedIn,
-        'loggingIn': Store.$states.loggingIn,
-        'loginFailed': Store.$states.loginFailed,
-        'authFailed': Store.$states.authFailed,
+      ...mapGetters({
+        'loggedIn': Store.$getters.loggedIn,
+        'loggingIn': Store.$getters.loggingIn,
+        'loginFailed': Store.$getters.loginFailed,
+        'authFailed': Store.$getters.authFailed,
       }),
 
       bothFieldErrors() {
-        return (!this.authFailed && this.loginFailed) ? 'Invalid JID or password' : null;
+        return (this.authFailed && this.loginFailed) ? 'Invalid JID or password' : null;
       },
 
       jidFieldErrors() {
-        return this.authFailed ? "Couldn't connect to server" : null;
+        return (this.loginFailed && !this.authFailed) ? "Couldn't connect to server" : null;
       },
     },
   }

--- a/pages/login.vue
+++ b/pages/login.vue
@@ -1,7 +1,7 @@
 <template>
   <login-dialog class="dialog"
                 @login="submit"
-                :loading="loading && !loggedIn"
+                :loading="loggingIn"
                 :both-field-errors="bothFieldErrors"
                 :jid-field-errors="jidFieldErrors"
   />
@@ -16,39 +16,26 @@
   export default {
     name: "login",
     components: {LoginDialog},
-    data() {
-      return {
-        loading: false,
-        wrongCredentials: false,
-        serverConnectionIssues: false,
+
+    async middleware({store, redirect}) {
+      // You're logged in; you have no business being here. Scram
+      if(store.state[Store.$states.loggedIn]) {
+        return redirect('/');
       }
+
+
+      // Try restoring a saved session and logging in that way
+      await store.dispatch(Store.$actions.tryRestoreSession);
+
+      // If we logged in that way, redirect to /
+      if(store.state[Store.$states.loggedIn])
+        return redirect('/');
     },
+
     methods: {
-      submit({jid, password, transports}) {
-        this.wrongCredentials = false;
-        this.serverConnectionIssues = false;
-        this.loading = true;
-
-        this.login({jid, password, transports});
-
-        this.$stanza.client.on("auth:success", () => {
-          this.$router.push('/loggedIn')
-        });
-      },
-
-      failedAuth() {
-        this.wrongCredentials = true;
-      },
-
-      transportDisconnected() {
-        if (this.wrongCredentials) {
-          console.warn("Incorrect username or password");
-        } else {
-          this.serverConnectionIssues = true;
-          console.warn("Couldn't connect to XMPP server!");
-        }
-
-        this.loading = false;
+      async submit({jid, password, transports}) {
+        await this.login({jid, password, transports});
+        if(this.loggedIn) return this.redirect('/');
       },
 
       ...mapActions({
@@ -59,26 +46,19 @@
     computed: {
       ...mapState({
         'loggedIn': Store.$states.loggedIn,
+        'loggingIn': Store.$states.loggingIn,
+        'loginFailed': Store.$states.loginFailed,
+        'authFailed': Store.$states.authFailed,
       }),
 
       bothFieldErrors() {
-        return this.wrongCredentials ? 'Invalid JID or password' : null;
+        return (!this.authFailed && this.loginFailed) ? 'Invalid JID or password' : null;
       },
 
       jidFieldErrors() {
-        return this.serverConnectionIssues ? "Couldn't connect to server" : null;
+        return this.authFailed ? "Couldn't connect to server" : null;
       },
     },
-
-    mounted() {
-      this.$stanza.client.on('auth:failed', this.failedAuth);
-      this.$stanza.client.on('--transport-disconnected', this.transportDisconnected);
-    },
-
-    destroyed() {
-      this.$stanza.client.off('auth:failed', this.failedAuth);
-      this.$stanza.client.off('--transport-disconnected', this.transportDisconnected);
-    }
   }
 </script>
 

--- a/pages/logout.vue
+++ b/pages/logout.vue
@@ -1,0 +1,17 @@
+<template>
+
+</template>
+
+<script>
+  export default {
+    name: "logout",
+    middleware({ $stanza, redirect }) {
+      $stanza.logout();
+      return redirect('/login');
+    }
+  }
+</script>
+
+<style scoped>
+
+</style>

--- a/plugins/stanza.js
+++ b/plugins/stanza.js
@@ -14,16 +14,28 @@ const determineMessageMapKey = (ctx, m) => {
 }
 
 const generateFunctions = (ctx) => ({
-    determineMessageMapKey: m => determineMessageMapKey(ctx, m),
-    disconnect: () => {
+    determineMessageMapKey(m) {
+        determineMessageMapKey(ctx, m)
+    },
+    updateConfig(...args) {
+        client.updateConfig(...args);
+    },
+    connect() {
+        client.connect();
+    },
+    disconnect() {
         client.disconnect();
-        ctx.commit(Store.$mutations.updateLoginState, {
+    },
+    logout() {
+        this.disconnect();
+
+        ctx.store.commit(Store.$mutations.updateLoginState, {
             loggedIn: false,
             loggingIn: false,
             loginFailed: false,
             authFailed: false,
         });
-        ctx.commit(Store.$mutations.setPassword, null);
+        ctx.store.commit(Store.$mutations.unsetPassword, null);
     },
 });
 

--- a/plugins/stanza.js
+++ b/plugins/stanza.js
@@ -15,6 +15,16 @@ const determineMessageMapKey = (ctx, m) => {
 
 const generateFunctions = (ctx) => ({
     determineMessageMapKey: m => determineMessageMapKey(ctx, m),
+    disconnect: () => {
+        client.disconnect();
+        ctx.commit(Store.$mutations.updateLoginState, {
+            loggedIn: false,
+            loggingIn: false,
+            loginFailed: false,
+            authFailed: false,
+        });
+        ctx.commit(Store.$mutations.setPassword, null);
+    },
 });
 
 const setupListeners = ctx => {

--- a/plugins/stanza.js
+++ b/plugins/stanza.js
@@ -107,6 +107,11 @@ const setupListeners = ctx => {
             });
         }
     });
+
+    /** STREAM MANAGEMENT RESUMPTION DATA CACHING **/
+    client.sm.cache(cache => {
+        ctx.store.commit(Store.$mutations.setStreamManagement, cache);
+    });
 }
 
 export default (ctx, inject) => {

--- a/plugins/stanza.js
+++ b/plugins/stanza.js
@@ -1,14 +1,122 @@
 import * as XMPP from 'stanza';
+import { MessageStore } from "@/store/messages";
+import { Store } from "@/store";
+import account from "stanza/plugins/account";
 
 const client = XMPP.createClient(undefined);
 
-const generateFunctions = (ctx) => ({
+const determineMessageMapKey = (ctx, m) => {
+    const me = ctx.store.state[ Store.$states.jid ];
+    if(m.from === me) {
+        return m.to;
+    }
 
+    return m.from;
+}
+
+const generateFunctions = (ctx) => ({
+    determineMessageMapKey: m => determineMessageMapKey(ctx, m),
 });
 
-const setupListeners = async ctx => {}
+const setupListeners = async ctx => {
+    function commit(mutation, ...args) {
+        return ctx.store.commit(`${MessageStore.namespace}/${mutation}`, ...args);
+    }
+
+    function get(getter, ...args) {
+        return ctx.store.getters[`${MessageStore.namespace}/${getter}`](...args);
+    }
+
+    client.on('session:started', () => {
+        client.getRoster().then(roster => {
+            ctx.store.commit(Store.$mutations.setRoster, roster);
+        });
+        client.sendPresence();
+        client.enableCarbons();
+        client.enableKeepAlive();
+    });
+
+    /**
+     * INCOMING (DIRECT) CHAT MESSAGES
+     */
+
+    client.on('chat', message => {
+        const jid = determineMessageMapKey(ctx, message);
+        commit(MessageStore.$mutations.addMessage, {
+            jid,
+            message,
+        });
+    });
+
+    /**
+     * STREAM RESUMPTION (MESSAGE DELIVERY STATE) HANDLING
+     */
+
+    client.on('message:sent', (m, carbon) => {
+        commit(MessageStore.$mutations.setMessageState, {
+            id: m.id,
+            state: {
+                server: carbon,
+                muc: false,
+                hibernated: false,
+                failed: false,
+                retry: false
+            }
+        });
+    });
+
+    client.on('message:acked', m => {
+        console.log("message:acked", m)
+        if (get(MessageStore.$getters.hasMessage, m.id)) {
+            commit(MessageStore.$mutations.setMessageState, {
+                id: m.id,
+                state: {
+                    server: true,
+                    muc: false,
+                }
+            });
+        }
+    });
+
+    client.on('message:hibernated', m => {
+        if (get(MessageStore.$getters.hasMessage, m.id)) {
+            commit(MessageStore.$mutations.setMessageState, {
+                id: m.id,
+                state: {
+                    hibernated: true,
+                }
+            });
+        }
+    });
+
+    client.on('message:retry', m => {
+        if (get(MessageStore.$getters.hasMessage, m.id)) {
+            commit(MessageStore.$mutations.setMessageState, {
+                id: m.id,
+                state: {
+                    retry: true,
+                }
+            });
+        }
+    });
+
+    client.on('message:failed', m => {
+        if (get(MessageStore.$getters.hasMessage, m.id)) {
+            commit(MessageStore.$mutations.setMessageState, {
+                id: m.id,
+                state: {
+                    failed: true,
+                }
+            });
+        }
+    });
+}
 
 export default (ctx, inject) => {
+    setupListeners(ctx);
+
+    // client.on('chat', console.log);
+
     inject("stanza", {
         client,
         ...generateFunctions(ctx),

--- a/plugins/stanza.js
+++ b/plugins/stanza.js
@@ -48,6 +48,7 @@ const setupListeners = ctx => {
         return ctx.store.getters[`${MessageStore.namespace}/${getter}`](...args);
     }
 
+    // TODO: Sometimes successful connections don't trigger session:started
     client.on('session:started', () => {
         client.getRoster().then(roster => {
             ctx.store.commit(Store.$mutations.setRoster, roster);
@@ -85,7 +86,6 @@ const setupListeners = ctx => {
     });
 
     client.on('message:acked', m => {
-        console.log("message:acked", m)
         if (get(MessageStore.$getters.hasMessage, m.id)) {
             commit(MessageStore.$mutations.updateMessageState, {
                 id: m.id,

--- a/store/index.js
+++ b/store/index.js
@@ -1,4 +1,7 @@
-import * as XMPP from 'stanza';
+import { Utils } from 'stanza';
+
+import * as storage from '@/assets/storage'
+import {loadFromSecure} from "@/assets/storage";
 
 const $states = {
     jid: 'JID',
@@ -13,7 +16,10 @@ const $states = {
     // @see stanza.js/createClient()
     transports: 'TRANSPORTS',
 
+    loggingIn: 'LOGIN_IN',
     loggedIn: 'LOGGED_IN',
+    loginFailed: 'LOGIN_FAILED',
+    authFailed: 'AUTH_FAILED',
 
     streamManagement: 'STREAM_MANAGEMENT',
 
@@ -25,15 +31,23 @@ const $states = {
 };
 
 const $getters = {};
+
 const $actions = {
     login: 'LOGIN',
+    tryRestoreSession: 'TRY_RESTORE_SESSION',
 };
+
 const $mutations = {
     setJid: 'SET_JID',
     setServer: 'SET_SERVER',
     setPassword: 'SET_PASSWORD',
     setTransports: 'SET_TRANSPORTS',
+
     setLoggedIn: 'SET_LOGGED_IN',
+    setLoggingIn: 'SET_LOGGING_IN',
+    setLoginFailed: 'SET_LOGIN_FAILED',
+    setAuthFailed: 'SET_AUTH_FAILED',
+
     setStreamManagement: 'SET_STREAM_MANAGEMENT',
     setAccount: 'SET_ACCOUNT',
     setRoster: 'SET_ROSTER',
@@ -44,7 +58,11 @@ export const state = () => ({
     [$states.server]: '',
     [$states.password]: '',
     [$states.transports]: {},
+
     [$states.loggedIn]: false,
+    [$states.loggingIn]: false,
+    [$states.loginFailed]: false,
+
     [$states.streamManagement]: null,
     [$states.account]: null,
     [$states.roster]: null,
@@ -52,33 +70,102 @@ export const state = () => ({
 
 export const getters = {};
 export const actions = {
-    async [$actions.login]({ commit, state }, { jid, password, server, transports }) {
-        let options = { jid, password, server, transports: transports || {bosh:true,websocket:true} };
+    async [$actions.tryRestoreSession]({ commit, dispatch }) {
+        try {
+            const smString = storage.session.getItem($states.streamManagement);
+            const cached = JSON.parse(smString, Utils.reviveData);
+
+            if(cached) {
+                this.$stanza.client.sm.load(cached);
+                commit($mutations.setStreamManagement, smString)
+            }
+        } catch (e) {
+            console.debug("Couldn't restore session management cache", e);
+        }
+
+        try {
+            const [jid, server, password, transports] = loadFromSecure(
+                $states.jid, $states.server, $states.password, $states.transports
+            );
+
+            await dispatch($actions.login, {jid, server, password, transports});
+        } catch (e) {
+            console.debug("Couldn't restore credentials", e);
+        }
+    },
+
+    async [$actions.login]({ commit }, { jid, password, server, transports }) {
+        console.debug("Indeed im trying to log in", jid, password, server, transports)
+        let options = { jid, password, server: server || undefined, transports: transports || {bosh:true,websocket:true} };
         this.$stanza.client.updateConfig(options);
 
         this.$stanza.client.connect();
-        this.$stanza.client.once("auth:success", () => {
+        commit($mutations.setLoggingIn, true);
+
+        this.$stanza.client.on("auth:failed", () => {
+            commit($mutations.setLoggedIn, false);
+            commit($mutations.setLoginFailed, true);
+            commit($mutations.setAuthFailed, true);
+        });
+
+        await Promise.any([new Promise(resolve => this.$stanza.client.once("connected", () => {
             commit($mutations.setLoggedIn, true);
+            commit($mutations.setLoggingIn, false);
+            commit($mutations.setLoginFailed, false);
+            commit($mutations.setAuthFailed, false);
+
             commit($mutations.setJid, jid);
             commit($mutations.setPassword, password);
+            resolve()
+        })),
+
+        new Promise(resolve => this.$stanza.client.once("disconnected", () => {
+            commit($mutations.setLoggedIn, false);
+            commit($mutations.setLoggingIn, false);
+            commit($mutations.setLoginFailed, true);
+            commit($mutations.setAuthFailed, false);
+
+            commit($mutations.setJid, "");
+            commit($mutations.setPassword, "");
+            resolve()
+        }))]);
+
+        this.$stanza.client.sm.cache(cache => {
+            commit($mutations.setStreamManagement, cache);
         });
     }
 };
 export const mutations = {
     [$mutations.setJid] ( state, data ) {
         state[$states.jid] = data;
+        storage.secure.setItem($states.jid, JSON.stringify(data));
     },
 
     [$mutations.setServer] ( state, data ) {
         state[$states.server] = data;
+        storage.secure.setItem($states.server, JSON.stringify(data));
     },
 
     [$mutations.setPassword] ( state, data ) {
         state[$states.password] = data;
+        storage.secure.setItem($states.password, JSON.stringify(data));
     },
 
     [$mutations.setTransports] ( state, data ) {
         state[$states.transports] = data;
+        storage.secure.setItem($states.transports, JSON.stringify(data));
+    },
+
+    [$mutations.setLoggingIn] ( state, data ) {
+        state[$states.loggingIn] = data;
+    },
+
+    [$mutations.setAuthFailed] ( state, data ) {
+        state[$states.authFailed] = data;
+    },
+
+    [$mutations.setLoginFailed] ( state, data ) {
+        state[$states.loginFailed] = data;
     },
 
     [$mutations.setLoggedIn] ( state, data ) {
@@ -86,8 +173,9 @@ export const mutations = {
     },
 
     [$mutations.setStreamManagement] ( state, data ) {
-        // TODO: save to session cache
-        state[$states.streamManagement] = data;
+        const string = JSON.stringify(data);
+        storage.session.setItem($states.streamManagement, string);
+        state[$states.streamManagement] = string;
     },
 
     [$mutations.setAccount] ( state, data ) {

--- a/store/index.js
+++ b/store/index.js
@@ -104,8 +104,10 @@ export const actions = {
         try {
             const cached = JSON.parse(storage.session.getItem($states.streamManagement), Utils.reviveData);
 
-            this.$stanza.client.sm.load(cached);
-            commit($mutations.setStreamManagement, cached)
+            if(cached) {
+                this.$stanza.client.sm.load(cached);
+                commit($mutations.setStreamManagement, cached)
+            }
         } catch (e) {
             console.debug("Couldn't restore session management cache", e);
         }
@@ -126,8 +128,15 @@ export const actions = {
         }
     },
 
-    async [$actions.login]({ commit }, { jid, password, server, transports }) {
-        let options = { jid, password, server: server || undefined, transports: transports || {bosh:true,websocket:true} };
+    async [$actions.login]({ commit }, { jid, password, server, transports, resource }) {
+        let options = {
+            jid,
+            password,
+            server: server || undefined,
+            transports: transports || {bosh: true, websocket: true},
+            resource: resource || `${Math.round(Math.random() * 100)}-bonfire`,
+            allowReconnect: true,
+        };
         this.$stanza.client.updateConfig(options);
 
         this.$stanza.client.connect();

--- a/store/index.js
+++ b/store/index.js
@@ -53,6 +53,7 @@ const $mutations = {
     setJid: 'SET_JID',
     setServer: 'SET_SERVER',
     setPassword: 'SET_PASSWORD',
+    unsetPassword: 'UNSET_PASSWORD',
     setTransports: 'SET_TRANSPORTS',
 
     updateLoginState: 'UPDATE_LOGIN_STATE',
@@ -195,9 +196,9 @@ const generateMutations = (storage, ...names) => {
     } else if( typeof storage === "string") {
         names.push(storage);
 
-        const mutationName = `SET_${name}`;
-
         for (let name of names) {
+            const mutationName = `SET_${name}`;
+
             mutations[mutationName] = (state, data) => {
                 state[name] = data;
             }
@@ -212,6 +213,11 @@ export const mutations = {
         $states.jid, $states.password, $states.server, $states.transports),
 
     ...generateMutations($states.account, $states.roster),
+
+    [$mutations.unsetPassword] ( state ) {
+        state[$states.password] = "";
+        storage.secure.removeItem($states.password);
+    },
 
     [$mutations.updateLoginState] ( state, data ) {
         state[$states.loginState] = Object.assign(state[$states.loginState], data);

--- a/store/index.js
+++ b/store/index.js
@@ -14,6 +14,14 @@ const $states = {
     transports: 'TRANSPORTS',
 
     loggedIn: 'LOGGED_IN',
+
+    streamManagement: 'STREAM_MANAGEMENT',
+
+    // See stanza.js/AccountManagement
+    account: 'ACCOUNT',
+
+    // See stanza.js/Roster
+    roster: 'ROSTER',
 };
 
 const $getters = {};
@@ -26,6 +34,9 @@ const $mutations = {
     setPassword: 'SET_PASSWORD',
     setTransports: 'SET_TRANSPORTS',
     setLoggedIn: 'SET_LOGGED_IN',
+    setStreamManagement: 'SET_STREAM_MANAGEMENT',
+    setAccount: 'SET_ACCOUNT',
+    setRoster: 'SET_ROSTER',
 }
 
 export const state = () => ({
@@ -34,6 +45,9 @@ export const state = () => ({
     [$states.password]: '',
     [$states.transports]: {},
     [$states.loggedIn]: false,
+    [$states.streamManagement]: null,
+    [$states.account]: null,
+    [$states.roster]: null,
 });
 
 export const getters = {};
@@ -69,6 +83,19 @@ export const mutations = {
 
     [$mutations.setLoggedIn] ( state, data ) {
         state[$states.loggedIn] = data;
+    },
+
+    [$mutations.setStreamManagement] ( state, data ) {
+        // TODO: save to session cache
+        state[$states.streamManagement] = data;
+    },
+
+    [$mutations.setAccount] ( state, data ) {
+        state[$states.account] = data;
+    },
+
+    [$mutations.setRoster] ( state, data ) {
+        state[$states.roster] = data;
     },
 };
 

--- a/store/messages.js
+++ b/store/messages.js
@@ -1,0 +1,85 @@
+import * as XMPP from 'stanza';
+
+/**
+ * Message state definition. Due to a lack of typescript, this will have to settle:
+ * {
+ *     retry: message is being resent automatically
+ *     failed: message couldn't be resent (reqs user interaction)
+ *     hibernated: no network, different from retry?
+ *     server: has our server recieved the message
+ *     muc: has the destination MUC received
+ * }
+ *
+ * Messages really only have a couple of delivery states:
+ *  NotReceived (sending, retrying, hibernated), Received (MUC and server), Failed (failed or error)
+ *
+ */
+
+const $states = {
+    // Map< JID -> [Message] >
+    messages: 'MESSAGES',
+
+    // Map< ID -> Message >
+    messagesById: 'MESSAGES_BY_ID',
+
+    // Map< ID -> MessageState >
+    messageStateById: 'MESSAGE_STATE_BY_ID',
+};
+
+const $getters = {
+    hasMessage: 'HAS_MESSAGE',
+};
+const $actions = {};
+const $mutations = {
+    addMessage: 'ADD_MESSAGE',
+    setMessage: 'SET_MESSAGE',
+    setMessageState: 'SET_MESSAGE_STATE',
+}
+
+export const state = () => ({
+    [$states.messages]: new Map(),
+    [$states.messagesById]: new Map(),
+    [$states.messageStateById]: new Map(),
+});
+
+export const getters = {
+    [$getters.hasMessage]: state => id => {
+        return state[$states.messagesById].has(id);
+    },
+};
+export const actions = {};
+
+const resourceRegex = new RegExp("\\/.+$");
+export const mutations = {
+    [$mutations.addMessage] ( state, { jid, message, state: messageState } ) {
+        const bareJid = jid.replace(resourceRegex, "");
+        if(!state[$states.messages].has(bareJid))
+            state[$states.messages].set(bareJid, []);
+
+        state[$states.messages].get(bareJid).push(message);
+        state[$states.messagesById].set(message.id, message);
+
+        if(messageState)
+            state[$states.messageStateById].set(message.id, messageState)
+    },
+
+    [$mutations.setMessage] ( state, { jid, message, state: messageState } ) {
+        // This tests if the two maps really point to the same objects...
+        if(data.jid)
+            state[$states.messages].set(jid, message);
+        else if(data.id)
+            state[$states.messagesById].set(message.id, message);
+
+        if(messageState)
+            state[$states.messageStateById].set(message.id, messageState);
+    },
+
+    [$mutations.setMessageState] ( state, { id, state: messageState } ) {
+        state[$states.messageStateById].set(id, messageState)
+    }
+};
+
+export const MessageStore = {
+    namespace: 'messages',
+    $getters, $mutations, $actions, $states
+};


### PR DESCRIPTION
Sessions (as per Stream Management), as well as credentials are stored locally, and middleware will properly attempt relogging (or if that fails, redirecting to `/login`).

Added `/logout` route to logout.

Received chat messages are stored very inefficiently to local storage.

Requested resource is now `n-bonfire` where `n` is a random number from 0 to 100.