### PR TITLE
feat(scroll): add OverlayScrollbars plugin

### DIFF
--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -44,7 +44,8 @@ export default {
 
   // Plugins to run before rendering page: https://go.nuxtjs.dev/config-plugins
   plugins: [
-      '@/plugins/stanza.js'
+      '@/plugins/stanza.js',
+      '@/plugins/overlayscrollbars.js',
   ],
 
   // Auto import components: https://go.nuxtjs.dev/config-components

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,8 @@
         "fuzzy-matching": "^0.4.3",
         "lz4js": "^0.2.0",
         "nuxt": "^2.14.12",
+        "overlayscrollbars": "^1.13.1",
+        "overlayscrollbars-vue": "^0.2.2",
         "stanza": "^12.15.0"
       },
       "devDependencies": {
@@ -9929,6 +9931,20 @@
       "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/overlayscrollbars": {
+      "version": "1.13.1",
+      "resolved": "https://registry.npmjs.org/overlayscrollbars/-/overlayscrollbars-1.13.1.tgz",
+      "integrity": "sha512-gIQfzgGgu1wy80EB4/6DaJGHMEGmizq27xHIESrzXq0Y/J0Ay1P3DWk6tuVmEPIZH15zaBlxeEJOqdJKmowHCQ=="
+    },
+    "node_modules/overlayscrollbars-vue": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/overlayscrollbars-vue/-/overlayscrollbars-vue-0.2.2.tgz",
+      "integrity": "sha512-JpDkM+fkNp7YbZxZNf9cbSWCa1tylaSUkmdhux+qtVFekH4zpZpM8+GRtOgs7YDDWyVNPkUBQ8FnMRMoBNfoJw==",
+      "peerDependencies": {
+        "overlayscrollbars": "^1.10.0",
+        "vue": "^2.6.0"
       }
     },
     "node_modules/p-defer": {
@@ -23614,6 +23630,17 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
       "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ="
+    },
+    "overlayscrollbars": {
+      "version": "1.13.1",
+      "resolved": "https://registry.npmjs.org/overlayscrollbars/-/overlayscrollbars-1.13.1.tgz",
+      "integrity": "sha512-gIQfzgGgu1wy80EB4/6DaJGHMEGmizq27xHIESrzXq0Y/J0Ay1P3DWk6tuVmEPIZH15zaBlxeEJOqdJKmowHCQ=="
+    },
+    "overlayscrollbars-vue": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/overlayscrollbars-vue/-/overlayscrollbars-vue-0.2.2.tgz",
+      "integrity": "sha512-JpDkM+fkNp7YbZxZNf9cbSWCa1tylaSUkmdhux+qtVFekH4zpZpM8+GRtOgs7YDDWyVNPkUBQ8FnMRMoBNfoJw==",
+      "requires": {}
     },
     "p-defer": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,8 @@
     "fuzzy-matching": "^0.4.3",
     "lz4js": "^0.2.0",
     "nuxt": "^2.14.12",
+    "overlayscrollbars": "^1.13.1",
+    "overlayscrollbars-vue": "^0.2.2",
     "stanza": "^12.15.0"
   },
   "devDependencies": {

--- a/plugins/overlayscrollbars.js
+++ b/plugins/overlayscrollbars.js
@@ -1,0 +1,14 @@
+import "overlayscrollbars/css/OverlayScrollbars.css";
+import Vue from 'vue';
+import OverlayScrollbars from 'overlayscrollbars';
+import { OverlayScrollbarsPlugin, OverlayScrollbarsComponent } from "overlayscrollbars-vue";
+
+Vue.use(OverlayScrollbarsPlugin);
+
+Vue.component('overlay-scrollbars', OverlayScrollbarsComponent);
+
+OverlayScrollbars(document.body, {
+    nativeScrollbarsOverlaid: {
+        initialize: false
+    }
+});


### PR DESCRIPTION
Elements that need a custom JS scrollbar can be wrapped in `<overlay-scrollbars>` for this purpose

Provides mechanism for fixing #24.