### PR TITLE
feat: add settings system and screen

### DIFF
--- a/assets/_sizes.scss
+++ b/assets/_sizes.scss
@@ -8,3 +8,6 @@ $badge-dot-height: $badge-dot-width;
 $badge-dot-border-radius: 100% !important;
 
 $chat-search-results-width: 400px;
+
+$exit-button-size: 2.5rem;
+$exit-button-left-margin: 28px;

--- a/assets/settings/menuList.js
+++ b/assets/settings/menuList.js
@@ -1,0 +1,27 @@
+export default [
+    {
+        header: "User Settings",
+        content: [
+            {
+                title: "Privacy",
+                type: "submenu",
+                to: "privacy"
+            }
+        ]
+    },
+    {
+        content: [
+            {
+                title: "About",
+                type: "submenu",
+                to: "about"
+            },
+            {
+                title: "Log Out",
+                type: "nuxt",
+                to: "/logout",
+                color: "#fb4934",
+            }
+        ]
+    }
+];

--- a/assets/utilities.scss
+++ b/assets/utilities.scss
@@ -41,7 +41,7 @@ $height-width-helper-sizes: splitIntoSteps(100, 20);
   -ms-flex-pack: justify !important;
 }
 
-.clickable > * {
+.clickable, .clickable > * {
   cursor: pointer;
 }
 
@@ -79,6 +79,7 @@ $position-values: (absolute, relative, fixed, static);
     content: "";
 
     @extend .position-absolute, .w-100, .h-100;
+    left: 0; right: 0;
 
     z-index: 1;
 

--- a/components/Avatar.vue
+++ b/components/Avatar.vue
@@ -11,7 +11,7 @@
     name: "Avatar",
 
     props: {
-      size: Number,
+      size: Number | String,
       jid: String,
     },
 

--- a/components/Roster/RosterItem/BaseRosterItem.vue
+++ b/components/Roster/RosterItem/BaseRosterItem.vue
@@ -139,6 +139,7 @@
 
   // Vuetify sets line-height to 1.5/24px, so we reset it here
   .main-container {
+    width: 0; // Makes the container shrink when available width < content width
     line-height: 1;
   }
 </style>

--- a/components/SelfBar.vue
+++ b/components/SelfBar.vue
@@ -1,0 +1,67 @@
+<template>
+  <div class="self-bar d-flex align-center px-3 white--text">
+    <avatar :jid="jid" size="36px" class="flex-grow-0"/>
+
+    <main class="d-flex flex-column hide-overflow ml-2 local-status flex-grow-1">
+      <span class="local-part">{{localPart}}</span>
+      <span v-if="statusMessage" class="status-message hide-overflow grey-700--text">{{statusMessage}}</span>
+    </main>
+
+    <aside class="ml-2">
+      <v-btn nuxt to="/settings" icon tile medium class="rounded">
+        <v-icon color="grey-900" size="1.5em">mdi-cog</v-icon>
+      </v-btn>
+    </aside>
+  </div>
+</template>
+
+<script>
+  import {mapGetters} from "vuex";
+  import {Store} from "@/store";
+
+  export default {
+    name: "SelfBar",
+    props: {
+      jid: String,
+    },
+    computed: {
+      ...mapGetters({
+        getPresence: Store.$getters.presence,
+      }),
+
+      localPart() {
+        return this.$stanza.getLocal(this.jid);
+      },
+
+      presence() { return this.getPresence(this.jid); },
+
+      available() { return this.presence?.available; },
+      statusMessage() { return this.presence?.status; },
+
+      onlineStatus() {
+        if(!this.available) return 'offline';
+        if(!this.presence?.show && this.available) return 'online';
+        return this.presence?.show;
+      },
+    },
+  }
+</script>
+
+<style scoped lang="scss">
+  .self-bar {
+    @include ensure-height(3.5rem);
+    font-size: .9rem;
+    line-height: .9rem;
+    background: map-get($black, "base");
+  }
+
+  .local-status {
+    //line-height: .9em;
+  }
+
+
+  .local-part {
+    font-weight: 700;
+  }
+
+</style>

--- a/components/Settings/MenuList.vue
+++ b/components/Settings/MenuList.vue
@@ -1,5 +1,5 @@
 <template>
-  <main class="menu-content px-2 ml-auto">
+  <main v-if="!mobile" class="menu-content px-2 ml-auto">
 
     <div class="menu-group" v-for="group in menuList">
       <div class="menu-group-header unselectable mx-2 grey-700--text" v-if="group.header">
@@ -17,14 +17,38 @@
 
     <slot/>
   </main>
+
+  <nav v-else>
+
+    <v-list subheader nav flat class="lhs-bg px-0 mt-1 white--text">
+      <v-list-item-group v-for="(group, i) in menuList" :key="i" class="lh-36">
+        <panel-title v-if="group.header && i !== 0" class="px-6">{{group.header}}</panel-title>
+
+        <v-divider v-else-if="i !== 0" class="my-2"/>
+
+        <v-list-item v-for="(item, j) in group.content" :key="j"
+                     append nuxt :to="item.to" class="px-6">
+          <v-list-item-title :style="{color: item.color}" :class="item.color || 'white--text'">{{item.title}}</v-list-item-title>
+        </v-list-item>
+      </v-list-item-group>
+    </v-list>
+
+  </nav>
 </template>
 
 <script>
+  import PanelTitle from '@/components/Settings/Panels/UI/PanelTitle';
+
   export default {
     name: "MenuList",
+    components: { PanelTitle },
     props: {
       menuList: Array,
       value: String,
+      mobile: {
+        type: Boolean,
+        default: false,
+      }
     },
 
     data() {
@@ -62,4 +86,7 @@
   font-weight: 700;
   line-height: 1;
 }
+
+.lhs-bg { background: map-get($black, "lighten") !important; }
+.lh-36 > *:not(.v-divider) { @include ensure-height(2.25em); }
 </style>

--- a/components/Settings/MenuList.vue
+++ b/components/Settings/MenuList.vue
@@ -1,0 +1,65 @@
+<template>
+  <main class="menu-content px-2 ml-auto">
+
+    <div class="menu-group" v-for="group in menuList">
+      <div class="menu-group-header unselectable mx-2 grey-700--text" v-if="group.header">
+        {{ group.header.toLocaleUpperCase() }}
+      </div>
+
+      <div class="menu-group-items">
+        <settings-menu-list-item v-for="(item, i) in group.content" :key="i"
+                                 :item="item" :selected="item.to === selected"
+                                 @select="select"/>
+      </div>
+
+      <v-divider class="mx-2 my-2"/>
+    </div>
+
+    <slot/>
+  </main>
+</template>
+
+<script>
+  export default {
+    name: "MenuList",
+    props: {
+      menuList: Array,
+      value: String,
+    },
+
+    data() {
+      return {
+        selectedSubmenu: null,
+      }
+    },
+
+    computed: {
+      selected: {
+        get() { return this.selectedSubmenu || this.value },
+        set(val) { this.selectedSubmenu = val; }
+      }
+    },
+
+    methods: {
+      select(to) {
+        this.selected = to;
+        this.$emit('input', to);
+      }
+    },
+  }
+</script>
+
+<style scoped lang="scss">
+.menu-content {
+  font-size: 1rem;
+  line-height: 2em;
+
+  @include ensure-width(200px);
+}
+
+.menu-group-header {
+  font-size: 0.8em;
+  font-weight: 700;
+  line-height: 1;
+}
+</style>

--- a/components/Settings/MenuList/Item.vue
+++ b/components/Settings/MenuList/Item.vue
@@ -1,0 +1,40 @@
+<template functional>
+  <div class="menu-group-item white--text">
+
+    <nuxt-link v-if="props.item.type === 'nuxt'" class="reset-link lighten-on-hover rounded d-block my-1 px-2"
+               :style="`color: ${props.item.color} !important`" :to="props.item.to">
+      {{ props.item.title }}
+    </nuxt-link>
+
+    <div v-else-if="props.item.type === 'submenu'" class="unselectable clickable lighten-on-hover rounded my-1 px-2"
+         :style="`color: ${props.item.color} !important`" :aria-selected="props.selected" @click="listeners.select(props.item.to)">
+      {{ props.item.title }}
+    </div>
+
+  </div>
+</template>
+
+<script>
+  export default {
+    name: "SettingsMenuListItem",
+    props: {
+      item: Object,
+      selected: {
+        type: Boolean,
+        default: false,
+      }
+    }
+  }
+</script>
+
+<style scoped lang="scss">
+// .lighten-on-hover sets the 'background' with a ::before, so we rounded that here
+.rounded:before {
+  border-radius: 4px;
+}
+
+.lighten-on-hover[aria-selected] {
+  background: map-get($greys, "300");
+  &:hover:before { background: inherit; }
+}
+</style>

--- a/components/Settings/Panels/About.vue
+++ b/components/Settings/Panels/About.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="white--text">
-    <panel-title>About</panel-title>
+    <panel-title v-if="!mobile">About</panel-title>
   </div>
 </template>
 
@@ -10,6 +10,7 @@
   export default {
     name: "about",
     components: {PanelTitle},
+    props: ['mobile'],
   }
 </script>
 

--- a/components/Settings/Panels/About.vue
+++ b/components/Settings/Panels/About.vue
@@ -1,0 +1,18 @@
+<template>
+  <div class="white--text">
+    <panel-title>About</panel-title>
+  </div>
+</template>
+
+<script>
+  import PanelTitle from "./UI/PanelTitle";
+
+  export default {
+    name: "about",
+    components: {PanelTitle},
+  }
+</script>
+
+<style scoped>
+
+</style>

--- a/components/Settings/Panels/Privacy.vue
+++ b/components/Settings/Panels/Privacy.vue
@@ -1,6 +1,6 @@
 <template>
-  <div class="white--text">
-    <panel-title>Privacy</panel-title>
+  <div class="white--text" :class="{'mt-2': mobile}">
+    <panel-title v-if="!mobile">Privacy</panel-title>
 
     <toggle setting="activeChatReceipts" name="Send Typing Receipts" subtitle="Enabling this will send a receipt to people you are chatting with that shows you are typing."/>
     <v-divider class="my-4"/>
@@ -18,6 +18,7 @@
   export default {
     name: "privacy",
     components: {Toggle, PanelTitle},
+    props: ['mobile'],
   }
 </script>
 

--- a/components/Settings/Panels/Privacy.vue
+++ b/components/Settings/Panels/Privacy.vue
@@ -2,11 +2,11 @@
   <div class="white--text">
     <panel-title>Privacy</panel-title>
 
-    <toggle name="Send Typing Receipts" subtitle="Enabling this will send a receipt to people you are chatting with that shows you are typing."/>
+    <toggle setting="activeChatReceipts" name="Send Typing Receipts" subtitle="Enabling this will send a receipt to people you are chatting with that shows you are typing."/>
     <v-divider class="my-4"/>
-    <toggle name="Send Message Read Receipts" subtitle="Enabling this will let other people see which of their messages you've seen."/>
+    <toggle setting="messageReadReceipts" name="Send Message Read Receipts" subtitle="Enabling this will let other people see which of their messages you've seen."/>
     <v-divider class="my-4"/>
-    <toggle name="Send Active Chat Receipts" subtitle="Enabling this will let other people know if you have a chat with them open."/>
+    <toggle setting="sendTypingReceipts" name="Send Active Chat Receipts" subtitle="Enabling this will let other people know if you have a chat with them open."/>
 
   </div>
 </template>

--- a/components/Settings/Panels/Privacy.vue
+++ b/components/Settings/Panels/Privacy.vue
@@ -1,0 +1,25 @@
+<template>
+  <div class="white--text">
+    <panel-title>Privacy</panel-title>
+
+    <toggle name="Send Typing Receipts" subtitle="Enabling this will send a receipt to people you are chatting with that shows you are typing."/>
+    <v-divider class="my-4"/>
+    <toggle name="Send Message Read Receipts" subtitle="Enabling this will let other people see which of their messages you've seen."/>
+    <v-divider class="my-4"/>
+    <toggle name="Send Active Chat Receipts" subtitle="Enabling this will let other people know if you have a chat with them open."/>
+
+  </div>
+</template>
+
+<script>
+  import Toggle from "./UI/Toggle";
+  import PanelTitle from "./UI/PanelTitle";
+
+  export default {
+    name: "privacy",
+    components: {Toggle, PanelTitle},
+  }
+</script>
+
+<style scoped lang="scss">
+</style>

--- a/components/Settings/Panels/UI/PanelTitle.vue
+++ b/components/Settings/Panels/UI/PanelTitle.vue
@@ -1,5 +1,5 @@
 <template functional>
-  <div class="panel-title unselectable mb-3">
+  <div class="panel-title unselectable mb-3" :class="[data.class, data.staticClass]">
     {{props.title}}
     <slot/>
   </div>

--- a/components/Settings/Panels/UI/PanelTitle.vue
+++ b/components/Settings/Panels/UI/PanelTitle.vue
@@ -1,0 +1,26 @@
+<template functional>
+  <div class="panel-title unselectable mb-3">
+    {{props.title}}
+    <slot/>
+  </div>
+</template>
+
+<script>
+export default {
+  name: "PanelTitle",
+  props: {
+    title: {
+      type: String,
+      required: false,
+    },
+  },
+}
+</script>
+
+<style scoped lang="scss">
+.panel-title {
+  vertical-align: top;
+  font-weight: 800;
+  text-transform: uppercase;
+}
+</style>

--- a/components/Settings/Panels/UI/Toggle.vue
+++ b/components/Settings/Panels/UI/Toggle.vue
@@ -5,7 +5,7 @@
       <div class="d-inline" @click="toggle">{{ name }}</div>
       <v-spacer class="align-self-stretch" @click="toggle"/>
       <v-switch :ripple="false" inset class="switch"
-        v-model="state"/>
+        v-model="storeValue"/>
     </div>
 
     <div class="toggle-group-subtitle">{{ subtitle }}</div>
@@ -13,6 +13,8 @@
 </template>
 
 <script>
+  import { SettingsStore } from "@/store/settings";
+
   export default {
     name: "Toggle",
     props: {
@@ -23,19 +25,45 @@
       subtitle: {
         type: String,
         required: false,
+      },
+
+      storeState: {
+        type: String,
+      },
+      storeSetter: {
+        type: String,
+        required: false,
+      },
+
+      setting: {
+        type: String,
+      },
+
+      storeNamespace: {
+        type: String,
+        required: false,
+        default: undefined
       }
     },
 
-    data() {
-      return {
-        state: false,
+    computed: {
+      namespace() {
+        return this.storeNamespace || SettingsStore.namespace;
+      },
+
+      stateName() {
+        return SettingsStore.$states[this.setting] || this.storeState;
+      },
+
+      storeValue: {
+        get()    { return this.$store.state[this.namespace][this.stateName]; },
+        set(val) { this.$store.commit(`${this.namespace}/${this.storeSetter || 'SET_' + this.stateName}`, val); },
       }
     },
 
     methods: {
       toggle() {
-        // TODO: change vuex store state
-        this.state = !this.state;
+        this.storeValue = !this.storeValue;
       }
     },
   }

--- a/components/Settings/Panels/UI/Toggle.vue
+++ b/components/Settings/Panels/UI/Toggle.vue
@@ -1,0 +1,62 @@
+<template>
+  <div class="mb-3 unselectable">
+
+    <div class="d-flex align-center clickable">
+      <div class="d-inline" @click="toggle">{{ name }}</div>
+      <v-spacer class="align-self-stretch" @click="toggle"/>
+      <v-switch :ripple="false" inset class="switch"
+        v-model="state"/>
+    </div>
+
+    <div class="toggle-group-subtitle">{{ subtitle }}</div>
+  </div>
+</template>
+
+<script>
+  export default {
+    name: "Toggle",
+    props: {
+      name: {
+        type: String,
+        required: true,
+      },
+      subtitle: {
+        type: String,
+        required: false,
+      }
+    },
+
+    data() {
+      return {
+        state: false,
+      }
+    },
+
+    methods: {
+      toggle() {
+        // TODO: change vuex store state
+        this.state = !this.state;
+      }
+    },
+  }
+</script>
+
+<style scoped lang="scss">
+.switch {
+  display: inline;
+  margin: 0;
+}
+
+.toggle-group-subtitle {
+  font-weight: 300;
+  font-size: .9em;
+  color: map-get($greys, "700");
+}
+
+*::v-deep .v-messages {
+  @include ensure-width(0);
+  @include ensure-height(0);
+  width: 0 !important;
+  height: 0 !important;
+}
+</style>

--- a/components/SideBar.vue
+++ b/components/SideBar.vue
@@ -1,13 +1,14 @@
 <template>
-  <div class="sidebar grey-100">
+  <div class="sidebar grey-100 d-flex flex-column">
     <header-bar pad-bottom/>
-    <overlay-scrollbars class="h-100 narrow-scrollbar"
+    <overlay-scrollbars class="narrow-scrollbar flex-grow-1"
       :options="{scrollbars: {autoHide: 'leave', autoHideDelay: 0}}">
       <roster-list
           :pinned="[]"
           :items="items"
           :selected-jid="selectedJid"/>
     </overlay-scrollbars>
+    <self-bar :jid="$stanza.client.jid"/>
   </div>
 </template>
 

--- a/layouts/mobileMenu.vue
+++ b/layouts/mobileMenu.vue
@@ -1,0 +1,54 @@
+<template>
+  <v-app dark>
+    <div id="app" class="d-flex flex-column black">
+      <header-bar class="align-content-center-inline unselectable header">
+        <v-btn icon @click="$router.back();" class="mx-2">
+          <v-icon size="1.66em" color="white">mdi-arrow-left</v-icon>
+        </v-btn>
+        <span class="header-title white--text">{{title}}</span>
+      </header-bar>
+      <v-main>
+        <nuxt class="pt-1"/>
+      </v-main>
+    </div>
+  </v-app>
+</template>
+
+<style lang="scss">
+  #app {
+    // Ensures the app container takes up just one screenful
+    position: absolute;
+    width: 100vw;
+    height: 100vh;
+
+    // Clips out everything that doesn't fit in the container
+    overflow: hidden;
+
+    // Solves some edge cases where on reload/HMR the view is stuck scrolled halfway
+    left: 0;
+    top: 0;
+  }
+
+  .header { z-index: 2; }
+
+  .header-title {
+    font-weight: 800;
+    font-size: 1.2em;
+    vertical-align: sub !important;
+  }
+</style>
+
+<script>
+  import SystemBar from "@/components/SystemBar";
+  import {Store} from "@/store";
+
+  export default {
+    layout: 'default',
+    components: {SystemBar},
+    computed: {
+      title() {
+        return this.$store.state[Store.$states.pageTitle];
+      }
+    }
+  }
+</script>

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -57,6 +57,7 @@ export default {
     // https://go.nuxtjs.dev/vuetify
     '@nuxtjs/vuetify',
     '@nuxtjs/style-resources',
+    '@nuxtjs/device',
   ],
 
   // Modules: https://go.nuxtjs.dev/config-modules

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,7 @@
         "@capacitor/core": "^2.4.6",
         "@commitlint/cli": "^12.0.0",
         "@commitlint/config-conventional": "^12.0.0",
+        "@nuxtjs/device": "^2.0.1",
         "@nuxtjs/vuetify": "^1.11.3",
         "commitizen": "^4.2.3",
         "cz-conventional-changelog": "^3.3.0",
@@ -2500,6 +2501,15 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/@nuxtjs/device": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@nuxtjs/device/-/device-2.0.1.tgz",
+      "integrity": "sha512-T/vUOj9DprR+EV/H2lKy3dj6zuYH0yRV8ZnLXK7WbR1ni4Wrj6nw/qqAy60SOfTupefdnDJPKP3pghwCRpBCbQ==",
+      "dev": true,
+      "dependencies": {
+        "defu": "^3.2.2"
       }
     },
     "node_modules/@nuxtjs/style-resources": {
@@ -17774,6 +17784,15 @@
             "lru-cache": "^6.0.0"
           }
         }
+      }
+    },
+    "@nuxtjs/device": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@nuxtjs/device/-/device-2.0.1.tgz",
+      "integrity": "sha512-T/vUOj9DprR+EV/H2lKy3dj6zuYH0yRV8ZnLXK7WbR1ni4Wrj6nw/qqAy60SOfTupefdnDJPKP3pghwCRpBCbQ==",
+      "dev": true,
+      "requires": {
+        "defu": "^3.2.2"
       }
     },
     "@nuxtjs/style-resources": {

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "@capacitor/core": "^2.4.6",
     "@commitlint/cli": "^12.0.0",
     "@commitlint/config-conventional": "^12.0.0",
+    "@nuxtjs/device": "^2.0.1",
     "@nuxtjs/vuetify": "^1.11.3",
     "commitizen": "^4.2.3",
     "cz-conventional-changelog": "^3.3.0",

--- a/pages/settings.vue
+++ b/pages/settings.vue
@@ -10,19 +10,24 @@
       </v-btn>
 
       <!--List of submenus-->
-      <settings-menu-list :menu-list="menuList" v-model="selectedSubmenu"/>
+      <overlay-scrollbars class="narrow-scrollbar h-100"
+        :options="{scrollbars: {autoHide: 'leave', autoHideDelay: 0}}">
+        <settings-menu-list :menu-list="menuList" v-model="selectedSubmenu"/>
+      </overlay-scrollbars>
     </div>
 
 
-    <!--Right hand side-->
-    <div class="panel pl-8" :style="{'padding-right': $vuetify.breakpoint.mdAndDown ? '42px' : '15vw' }">
+    <!--Right hand side scrollbar-->
+    <overlay-scrollbars class="h-100 panel">
 
       <!--Show the selected panel on the rhs-->
-      <keep-alive>
-        <component :is="selectedSubmenu"/>
-      </keep-alive>
+      <div class="ml-8 pb-16" style="margin-right: 15vw;">
+        <keep-alive>
+          <component :is="selectedSubmenu"/>
+        </keep-alive>
+      </div>
 
-    </div>
+    </overlay-scrollbars>
 
   </div>
 </template>
@@ -73,4 +78,7 @@ $exit-button-total-space: calc(#{$exit-button-size} + #{$exit-button-left-margin
 .menu { background: map-get($black, "lighten"); }
 .panel { background: map-get($greys, "300"); }
 
+.panel {
+  height: 100vh;
+}
 </style>

--- a/pages/settings.vue
+++ b/pages/settings.vue
@@ -1,0 +1,76 @@
+<template>
+  <div class="main w-100 h-100">
+
+    <!--Left hand side-->
+    <div class="menu">
+
+      <!--X exit button-->
+      <v-btn icon outlined @click="$router.back();" class="exit-button d-inline" color="grey-700">
+        <v-icon size="1.33rem" color="white">mdi-close</v-icon>
+      </v-btn>
+
+      <!--List of submenus-->
+      <settings-menu-list :menu-list="menuList" v-model="selectedSubmenu"/>
+    </div>
+
+
+    <!--Right hand side-->
+    <div class="panel pl-8" :style="{'padding-right': $vuetify.breakpoint.mdAndDown ? '42px' : '15vw' }">
+
+      <!--Show the selected panel on the rhs-->
+      <keep-alive>
+        <component :is="selectedSubmenu"/>
+      </keep-alive>
+
+    </div>
+
+  </div>
+</template>
+
+<script>
+import MenuList from '@/assets/settings/menuList.js';
+
+import About from "@/components/Settings/Panels/About";
+import Privacy from "@/components/Settings/Panels/Privacy";
+
+export default {
+  name: "settings",
+  layout: "fullscreen",
+  components: {About, Privacy},
+  data() {
+    return {
+      menuList: MenuList,
+      selectedSubmenu: MenuList[0].content[0].to,
+    }
+  },
+}
+</script>
+
+<style scoped lang="scss">
+$exit-button-total-space: calc(#{$exit-button-size} + #{$exit-button-left-margin}) !default;
+
+.main {
+  display: grid;
+  // 1:2 split, or shrink left side no less than min-content
+  grid-template-columns: minmax(min-content, 1fr) 2fr;
+}
+
+.menu {
+  display: grid;
+  // (Exit Button + Left Margin) | everything else
+  grid-template-columns: $exit-button-total-space auto
+}
+
+// Top-right alignment -- fake auto left margin
+.exit-button {
+  place-self: start end;
+}
+
+.main > * {
+  padding-top: 36px;
+}
+
+.menu { background: map-get($black, "lighten"); }
+.panel { background: map-get($greys, "300"); }
+
+</style>

--- a/pages/settings/_submenu.vue
+++ b/pages/settings/_submenu.vue
@@ -1,0 +1,45 @@
+<template>
+  <overlay-scrollbars class="h-100 component">
+    <component class="mx-6" :is="submenu" v-bind="{mobile: true}"/>
+  </overlay-scrollbars>
+</template>
+
+<script>
+  import About from "@/components/Settings/Panels/About";
+  import Privacy from "@/components/Settings/Panels/Privacy";
+
+  import {Store} from "@/store";
+
+  import MenuList from "@/assets/settings/menuList";
+
+  export default {
+    name: "submenu",
+    layout: "mobileMenu",
+    components: {About, Privacy},
+    computed: {
+      submenu() {
+        return this.$route.params.submenu;
+      },
+
+      title() {
+        for (const group of MenuList) {
+          const item = group.content.filter(x => x.to === this.$route.params.submenu)[0];
+          if(item) return item.title;
+        }
+
+        return '';
+      }
+    },
+    mounted() {
+      this.$store.commit(Store.$mutations.setPageTitle, this.title);
+    }
+  }
+</script>
+
+<style scoped lang="scss">
+.component { background: map-get($black, "lighten") !important; }
+
+// <overlay-scrollbars/> loses all its padding when destroyed, causing a visual jump
+// The solution: use margins. Unfortunately, one of its inner elements has a top padding, which we disable here.
+*::v-deep .os-content { padding-top: 0 !important; }
+</style>

--- a/pages/settings/index.vue
+++ b/pages/settings/index.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="main w-100 h-100">
+  <div class="main lhs-bg w-100 h-100" v-if="!$vuetify.breakpoint.smAndDown">
 
     <!--Left hand side-->
     <div class="menu">
@@ -12,42 +12,57 @@
       <!--List of submenus-->
       <overlay-scrollbars class="narrow-scrollbar h-100"
         :options="{scrollbars: {autoHide: 'leave', autoHideDelay: 0}}">
-        <settings-menu-list :menu-list="menuList" v-model="selectedSubmenu"/>
+        <settings-menu-list class="narrow-menu" :menu-list="menuList" v-model="selectedSubmenu"/>
       </overlay-scrollbars>
     </div>
 
 
     <!--Right hand side scrollbar-->
-    <overlay-scrollbars class="h-100 panel">
+    <overlay-scrollbars class="h-100 panel rhs-bg">
 
       <!--Show the selected panel on the rhs-->
       <div class="ml-8 pb-16" style="margin-right: 15vw;">
-        <keep-alive>
-          <component :is="selectedSubmenu"/>
-        </keep-alive>
+        <keep-alive><component :is="selectedSubmenu"/></keep-alive>
       </div>
 
     </overlay-scrollbars>
 
   </div>
+
+  <div v-else class="lhs-bg w-100 h-100">
+    <overlay-scrollbars class="narrow-scrollbar h-100"
+                        :options="{scrollbars: {autoHide: 'leave', autoHideDelay: 0}}">
+
+      <settings-menu-list class="lhs-bg" mobile :menu-list="menuList" v-model="selectedSubmenu"/>
+
+    </overlay-scrollbars>
+  </div>
 </template>
 
 <script>
-import MenuList from '@/assets/settings/menuList.js';
+import MenuList from 'assets/settings/menuList.js';
+
+import SettingsMenuList from '@/components/Settings/MenuList';
 
 import About from "@/components/Settings/Panels/About";
 import Privacy from "@/components/Settings/Panels/Privacy";
+import {Store} from "@/store";
 
 export default {
   name: "settings",
-  layout: "fullscreen",
-  components: {About, Privacy},
+  layout(ctx) {
+    return ctx.$vuetify.breakpoint.smAndDown ? "mobileMenu" : "fullscreen";
+  },
+  components: {SettingsMenuList, About, Privacy},
   data() {
     return {
       menuList: MenuList,
       selectedSubmenu: MenuList[0].content[0].to,
     }
   },
+  mounted() {
+    this.$store.commit(Store.$mutations.setPageTitle, "User Settings");
+  }
 }
 </script>
 
@@ -75,10 +90,14 @@ $exit-button-total-space: calc(#{$exit-button-size} + #{$exit-button-left-margin
   padding-top: 36px;
 }
 
-.menu { background: map-get($black, "lighten"); }
-.panel { background: map-get($greys, "300"); }
+.lhs-bg { background: map-get($black, "lighten") !important; }
+.rhs-bg { background: map-get($greys, "300") !important; }
 
 .panel {
   height: 100vh;
+}
+
+.narrow-menu {
+  @include ensure-width(200px);
 }
 </style>

--- a/pages/settings/index.vue
+++ b/pages/settings/index.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="main lhs-bg w-100 h-100" v-if="!$vuetify.breakpoint.smAndDown">
+  <div class="main lhs-bg w-100 h-100" v-if="!$device.isMobileOrTablet">
 
     <!--Left hand side-->
     <div class="menu">
@@ -51,7 +51,7 @@ import {Store} from "@/store";
 export default {
   name: "settings",
   layout(ctx) {
-    return ctx.$vuetify.breakpoint.smAndDown ? "mobileMenu" : "fullscreen";
+    return ctx.$device.isMobileOrTablet ? "mobileMenu" : "fullscreen";
   },
   components: {SettingsMenuList, About, Privacy},
   data() {

--- a/store/index.js
+++ b/store/index.js
@@ -8,6 +8,8 @@ import {loadFromSecure, loadFromSession} from '@/assets/storage'
 import Vue from 'vue';
 
 const $states = {
+    pageTitle: 'PAGE_TITLE',
+
     jid: 'JID',
 
     // In case the domain in the JID doesn't match
@@ -71,6 +73,8 @@ const $actions = {
 };
 
 const $mutations = {
+    setPageTitle: 'SET_PAGE_TITLE',
+
     setJid: 'SET_JID',
     setServer: 'SET_SERVER',
     setPassword: 'SET_PASSWORD',
@@ -95,6 +99,8 @@ const $mutations = {
 }
 
 export const state = () => ({
+    [$states.pageTitle]: '',
+
     [$states.jid]: '',
     [$states.server]: '',
     [$states.password]: '',
@@ -331,7 +337,7 @@ export const mutations = {
     ...generateMutations(storage.secure,
         $states.jid, $states.password, $states.server, $states.transports),
 
-    ...generateMutations($states.account, $states.roster, $states.loginDate, $states.activeChat),
+    ...generateMutations($states.account, $states.roster, $states.loginDate, $states.activeChat, $states.pageTitle),
 
     [$mutations.stanzaInitialized] ( state ) {
         state[$states.stanzaInitialized] = true;

--- a/store/index.js
+++ b/store/index.js
@@ -1,4 +1,4 @@
-import { MessageStore } from "@/store/messages";
+import { SettingsStore } from "@/store/settings";
 
 import { Utils } from 'stanza';
 
@@ -173,6 +173,9 @@ export const actions = {
                 commit($mutations.setPresence, presenceData);
             }
         }
+
+        // Restore user settings
+        dispatch(`${SettingsStore.namespace}/${SettingsStore.$actions.restoreUserSettings}`);
     },
 
     async [$actions.login]({ commit }, { jid, password, server, transports, resource }) {
@@ -401,7 +404,7 @@ export const mutations = {
             ...oldPresences,
             [resource]: { show: data.show, status: data.status, available: data.available, },
         });
-        
+
         let max = { available: false };
         for(const resource of Object.getOwnPropertyNames(state[$states.presences][bare])) {
             // Workaround to iterate through Vuex store reactive object keys

--- a/store/settings.js
+++ b/store/settings.js
@@ -1,0 +1,80 @@
+import { permanent, loadFromPermanent } from '@/assets/storage'
+
+const $states = {
+    sendTypingReceipts: 'SEND_TYPING_RECEIPTS',
+    messageReadReceipts: 'MESSAGE_READ_RECEIPTS',
+    activeChatReceipts: 'ACTIVE_CHAT_RECEIPTS',
+};
+
+const $actions = {
+    restoreUserSettings: 'RESTORE_USER_SETTINGS',
+};
+
+const $getters = {};
+
+/**
+ * Generates mutators by prepending SET_ to passed names.
+ * If `storage` is an object, it will generate mutations that also call storage.setItem(name, JSON.stringify(data))
+ * @param storage An object with method setItem(key, value). Optional.
+ * @param names Varargs list of $states field names
+ * @returns An object of mutations, for use with the object spread operator
+ */
+const generateMutations = (storage, ...names) => {
+    const mutations = {};
+
+    // Avoid putting this 'if' inside the generated functions, because it would get checked redundantly on each call
+    // The closest to a macro/constexpr if. Sadly, creates a lot of duplicate code
+    if( typeof storage === "object" ) {
+        for (let name of names) {
+            const mutationName = `SET_${name}`;
+
+            mutations[mutationName] = (state, data) => {
+                state[name] = data;
+                storage.setItem(name, JSON.stringify(data));
+            }
+        }
+    } else if( typeof storage === "string") {
+        names.push(storage);
+
+        for (let name of names) {
+            const mutationName = `SET_${name}`;
+
+            mutations[mutationName] = (state, data) => {
+                state[name] = data;
+            }
+        }
+    }
+
+    return mutations;
+}
+
+const $mutations = {
+    setActiveChatReceipts: 'SET_ACTIVE_CHAT_RECEIPTS',
+    setMessageReadReceipts: 'SET_MESSAGE_READ_RECEIPTS',
+    setSendTypingReceipts: 'SET_SEND_TYPING_RECEIPTS',
+}
+
+export const state = () => ({
+    [$states.activeChatReceipts]: false,
+    [$states.messageReadReceipts]: true,
+    [$states.sendTypingReceipts]: true,
+});
+
+export const mutations = {
+    ...generateMutations(permanent,
+        $states.activeChatReceipts, $states.messageReadReceipts, $states.sendTypingReceipts)
+}
+
+export const actions = {
+    [$actions.restoreUserSettings]({ commit }) {
+        for (const $state in $states) {
+            let [result] = loadFromPermanent($states[$state]);
+            if(result !== undefined) commit('SET_' + $states[$state], result);
+        }
+    }
+};
+
+export const SettingsStore = {
+    namespace: 'settings',
+    $getters, $mutations, $actions, $states
+};


### PR DESCRIPTION
New settings store for user settings. Has a restore action for restoring from `localStorage`, gets dispatched from the restore action in the root store.

Settings screen supports a mobile layout. The top level list is generated from `assets/settings/menuList.js`, and new submenus (or panels, as they're called), are components in `components/Settings/Panels`. They're displayed as dynamic components in the desktop view in `settings/index.vue`, and as a new page on mobile in `settings/_submenu.vue`

Panel-specific UI components are in `Settings/Panels/UI`. 