### PR TITLE
feat(layout): sidebar accordion

### DIFF
--- a/components/Accordion/Item.vue
+++ b/components/Accordion/Item.vue
@@ -3,7 +3,8 @@
 
     <!--Fixed height header-->
     <slot class="accordion--header" name="header">
-      <div class="accordion--header px-2 d-flex align-center clickable grey-900--text light-shadow"
+      <div class="accordion--header px-2 d-flex align-center clickable grey-900--text"
+           :class="{'light-shadow': expanded}"
            style="z-index: 2;"
            @click="$emit('expanded')">
         <span>{{ header }}</span>

--- a/components/Accordion/Item.vue
+++ b/components/Accordion/Item.vue
@@ -1,0 +1,55 @@
+<template>
+  <div class="d-flex flex-column accordion-item" :class="{'flex-grow-1': expanded}">
+
+    <!--Fixed height header-->
+    <slot class="accordion--header" name="header">
+      <div class="accordion--header px-2 d-flex align-center clickable grey-900--text light-shadow"
+           style="z-index: 2;"
+           @click="$emit('expanded')">
+        <span>{{ header }}</span>
+        <v-spacer/>
+        <v-icon size="16px" color="grey-900" :style="{ transform: chevronRotation }">mdi-chevron-right</v-icon>
+      </div>
+    </slot>
+
+    <!--Fill the rest of the space with the content-->
+    <div class="flex-grow-1 d-flex flex-column"
+         style="flex-basis: 0; min-height: 0"
+         v-show="expanded">
+      <slot/>
+    </div>
+  </div>
+</template>
+
+<script>
+export default {
+  name: "AccordionItem",
+  props: {
+    header: String,
+    expanded: Boolean,
+  },
+  computed: {
+    chevronRotation() {
+      return `rotate(${(this.expanded ? 90 : 0)}deg)`
+    },
+
+  },
+}
+</script>
+
+<style scoped lang="scss">
+$accordion-header-height: 2.5em;
+
+.accordion-item {
+  will-change: height, flex-grow;
+  transition-property: flex-grow;
+  transition-duration: .3s;
+  transition-timing-function: ease;
+}
+
+.accordion--header {
+  @include ensure-height($accordion-header-height);
+  background-color: map-get($black, "lighten");
+  font-weight: 800;
+}
+</style>

--- a/components/HeaderBar.vue
+++ b/components/HeaderBar.vue
@@ -1,5 +1,6 @@
 <template>
   <div class="header position-relative d-flex align-center"
+       style="z-index: 3"
        :style="styling"
        :class="{ 'lighten-on-hover': lightenOnHover, 'mb-2': padBottom, 'pl-4 pr-4': !mobile }">
     <v-btn v-if="mobile && menu" icon @click="back" class="mx-2">

--- a/components/SelfBar.vue
+++ b/components/SelfBar.vue
@@ -17,7 +17,7 @@
 </template>
 
 <script>
-import {mapGetters} from "vuex";
+import {mapGetters, mapState} from "vuex";
 import {Store} from "@/store";
 import {setSelector} from '@linusborg/vue-simple-portal'
 import StatusMenuTooltip from "@/components/StatusMenuTooltip";
@@ -36,8 +36,10 @@ setSelector('#app')
       }
     },
     computed: {
-      ...mapGetters({
-        getPresence: Store.$getters.presence,
+      ...mapState({
+        // TODO: Handle invisibility
+        onlineStatus: Store.$states.onlineStatus,
+        statusMessage: Store.$states.statusMessage,
       }),
 
       localPart() {
@@ -45,17 +47,6 @@ setSelector('#app')
       },
 
       domainPart() { return this.$stanza.getDomain(this.jid); },
-
-      presence() { return this.getPresence(this.jid); },
-
-      available() { return this.presence?.available; },
-      statusMessage() { return this.presence?.status; },
-
-      onlineStatus() {
-        if(!this.available) return 'offline';
-        if(!this.presence?.show && this.available) return 'online';
-        return this.presence?.show;
-      },
     },
     methods: {
       changeStatus(to) {

--- a/components/SideBar.vue
+++ b/components/SideBar.vue
@@ -1,12 +1,30 @@
 <template>
   <div class="sidebar grey-100 d-flex flex-column">
-    <header-bar pad-bottom/>
-    <simplebar class="narrow-scrollbar flex-grow-1">
-      <roster-list
-          :pinned="[]"
-          :items="items"
-          :selected-jid="selectedJid"/>
-    </simplebar>
+    <header-bar/>
+    <div class="d-flex flex-grow-1 flex-column">
+        <accordion-item header="Roster"
+                        :expanded="!expanded"
+                        @expanded="expanded = !expanded">
+            <simplebar class="narrow-scrollbar">
+              <roster-list
+                  :pinned="[]"
+                  :items="items"
+                  :selected-jid="selectedJid"/>
+            </simplebar>
+        </accordion-item>
+
+      <v-divider v-if="expanded"/>
+
+        <accordion-item header="Recent" :expanded="!!expanded"
+                        @expanded="expanded = !expanded">
+          <simplebar class="narrow-scrollbar">
+            <roster-list
+                :pinned="[]"
+                :items="items"
+                :selected-jid="selectedJid"/>
+          </simplebar>
+        </accordion-item>
+    </div>
     <self-bar :jid="$stanza.client.jid"/>
   </div>
 </template>
@@ -14,8 +32,20 @@
 <script>
   import { Store } from "@/store";
   import { mapState, mapGetters } from 'vuex';
+  import AccordionItem from "@/components/Accordion/Item";
 
   export default {
+    components: {AccordionItem},
+    data() {
+      return {
+        expanded: 0
+      }
+    },
+    methods: {
+      toggle() {
+        this.expanded = (this.expanded + 1) % 2
+      }
+    },
     computed: {
       ...mapState({
         roster: Store.$states.roster,

--- a/plugins/stanza.js
+++ b/plugins/stanza.js
@@ -167,8 +167,10 @@ const setupListeners = ctx => {
         ctx.store.commit(Store.$mutations.updatePresence, {available: false, ...presence});
     });
 
-    client.on('avatar', event => {
-        ctx.store.dispatch(Store.$actions.downloadAvatar, {jid: event.jid});
+    client.on('avatar', async event => {
+        // TODO: look more into the relevant XEPs for avatars
+        if(event.avatars[0].id !== await ctx.store.dispatch(Store.$actions.getAvatarId, event.jid))
+            ctx.store.dispatch(Store.$actions.downloadAvatar, {jid: event.jid, id: event.avatars[0].id});
     });
 
 


### PR DESCRIPTION
An accordion on the sidebar now resides, splitting in half, vertically, into `Roster` and `Recents`. The contents of both are the same, and are to be changed in further commits.

This branch also fixes #51, as well as an issue with the `<SelfBar/>` component displaying the wrong data (see: 14993ee)